### PR TITLE
add python3.12 info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,7 +92,7 @@ ipython_config.py
 #   However, in case of collaboration, if having platform-specific dependencies or dependencies
 #   having no cross-platform support, pipenv may install dependencies that don't work, or not
 #   install all needed dependencies.
-#Pipfile.lock
+Pipfile.lock
 
 # poetry
 #   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Source it by executing `source ~/.profile`. Now you are ready do create the virt
 ```sh
 pipenv --python 3
 pipenv shell
-# python 3.12 or higher (package removed from std lib, [Release Notes](https://docs.python.org/3.12/whatsnew/3.12.html))
+# python 3.12 or higher (package removed from std lib, https://docs.python.org/3.12/whatsnew/3.12.html):
 pip install setuptools
 pipenv install
 ```

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Source it by executing `source ~/.profile`. Now you are ready do create the virt
 ```sh
 pipenv --python 3
 pipenv shell
+# python 3.12 or higher (package removed from std lib, [Release Notes](https://docs.python.org/3.12/whatsnew/3.12.html))
+pip install setuptools
 pipenv install
 ```
 


### PR DESCRIPTION
On python3.12 the project cannot be build without installing a package that was removed from the std lib. Adding in readme

Also adding Pipfile.lock in .gitignore, since it was not checked in